### PR TITLE
Sort event keys alphabetically when getting them from ES

### DIFF
--- a/web/services/elasticsearch.ex
+++ b/web/services/elasticsearch.ex
@@ -127,7 +127,7 @@ defmodule Notifilter.Elasticsearch do
     url = "#{host}/notifilter/_mapping"
     {:ok, response} = HTTPoison.get(url, [])
     result = Poison.decode!(response.body)["notifilter"]["mappings"]["event"]["properties"]["data"]["properties"]
-    Map.keys(result)
+    Enum.sort(Map.keys(result))
   end
 
   defp handle_response({:ok, response}) do


### PR DESCRIPTION
We have some notifiers with a lot of different fields making it hard to select one to add as a filter, as you had to manually scan through the list. This makes that easier by sorting the event keys alphabetically.